### PR TITLE
Added ability to track vertical gesture changes through delegate method

### DIFF
--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -46,6 +46,8 @@ open class LPRTableView: UITableView {
 	fileprivate var scrollDisplayLink: CADisplayLink?
 	
 	fileprivate var feedbackGenerator: AnyObject?
+
+	fileprivate var previousGestureVerticalPosition: CGFloat?
 	
 	/** A Bool property that indicates whether long press to reorder is enabled. */
 	open var longPressReorderEnabled: Bool {
@@ -93,8 +95,6 @@ open class LPRTableView: UITableView {
 }
 
 extension LPRTableView {
-
-	fileprivate var previousGestureVerticalPosition: CGFloat?
 	
 	fileprivate func canMoveRowAt(indexPath: IndexPath) -> Bool {
 		return (dataSource?.responds(to: #selector(UITableViewDataSource.tableView(_:canMoveRowAt:))) == false) || (dataSource?.tableView?(self, canMoveRowAt: indexPath) == true)

--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -22,6 +22,9 @@ public protocol LPRTableViewDelegate: NSObjectProtocol {
 	
 	/** Called within an animation block when the dragging view is about to hide. */
 	@objc optional func tableView(_ tableView: UITableView, hideDraggingView view: UIView, at indexPath: IndexPath)
+
+	/** Called when the cell is dragged across the screen. Use this to get the gesture's information as its being executed. */
+	@objc optional func tableView(_ tableView: UITableView, draggingGestureChanged gesture: UILongPressGestureRecognizer)
 	
 }
 
@@ -190,6 +193,7 @@ extension LPRTableView {
 				if (location.y >= 0.0) && (location.y <= contentSize.height + 50.0) {
 					draggingView.center = CGPoint(x: center.x, y: location.y)
 				}
+				longPressReorderDelegate?.tableView?(self, draggingGestureChanged: gesture)
 			}
 			
 			var rect = bounds
@@ -401,6 +405,10 @@ open class LPRTableViewController: UITableViewController, LPRTableViewDelegate {
 	
 	/** Called within an animation block when the dragging view is about to hide. The default implementation of this method is empty—no need to call `super`. */
 	open func tableView(_ tableView: UITableView, hideDraggingView view: UIView, at indexPath: IndexPath) {
+		// Empty implementation, just to simplify overriding (and to show up in code completion).
+	}
+
+	open func tableView(_ tableView: UITableView, draggingGestureChanged gesture: UILongPressGestureRecognizer) {
 		// Empty implementation, just to simplify overriding (and to show up in code completion).
 	}
 	

--- a/LPRTableView.swift
+++ b/LPRTableView.swift
@@ -199,9 +199,11 @@ extension LPRTableView {
 				if let previousGestureVerticalPosition = self.previousGestureVerticalPosition {
 					if location.y != previousGestureVerticalPosition {
 						longPressReorderDelegate?.tableView?(self, draggingGestureChanged: gesture)
+						self.previousGestureVerticalPosition = location.y
 					}
 				} else {
 					longPressReorderDelegate?.tableView?(self, draggingGestureChanged: gesture)
+					self.previousGestureVerticalPosition = location.y
 				}
 			}
 			


### PR DESCRIPTION
You can now track changes in the vertical location of the gesture recognizer using `func tableView(_ tableView: UITableView, draggingGestureChanged gesture: UILongPressGestureRecognizer)`. 

Once the delegate method is implemented, you can use the `gesture` variable to check its information, such as its `location(in:)` another view. 

Use case:
My tableView is displayed within a `UIScrollView` which itself handles the scrolling of the view. This delegate method lets me know when I should scroll my main scrollView.